### PR TITLE
Relaxed react semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@babel/preset-react": "^7.0.0-beta.44"
   },
   "peerDependencies": {
-    "react": "^14.0.0"
+    "react": ">=14.0.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Used >=14.0.0 instead of ^14.0.0
because it did not allow for versions
15.x, 16.x, etc, even though it works fine
with it.